### PR TITLE
if there is no keypair given, generate one and use that

### DIFF
--- a/molecule/provisioners/openstackprovisioner.py
+++ b/molecule/provisioners/openstackprovisioner.py
@@ -37,7 +37,7 @@ class OpenstackProvisioner(baseprovisioner.BaseProvisioner):
 
     def set_keypair(self):
         keypair_name = self.get_keypair()
-        pub_key_file = self.molecule.config.config['openstack']['keyfile']
+        pub_key_file = self.get_keyfile()
 
         if self._openstack.search_keypairs(keypair_name):
             LOG.info('Keypair already exists. Skipping import.')
@@ -45,6 +45,14 @@ class OpenstackProvisioner(baseprovisioner.BaseProvisioner):
             LOG.info('Adding keypair...')
             self._openstack.create_keypair(keypair_name, open(
                 pub_key_file, 'r').read().strip())
+
+    def get_keyfile(self):
+        keyfile = self.molecule.config.config['openstack']['keyfile']
+        if (keyfile):
+            return keyfile
+        else:
+            LOG.info('Keyfile not specified. molecule will generate a temporary one.')
+            return utilities.generate_temp_ssh_key('id_rsa', 2048)
 
     def get_keypair(self):
         keypair_name = self.molecule.config.config['openstack']['keypair']

--- a/molecule/provisioners/openstackprovisioner.py
+++ b/molecule/provisioners/openstackprovisioner.py
@@ -36,7 +36,7 @@ class OpenstackProvisioner(baseprovisioner.BaseProvisioner):
         self._openstack = shade.openstack_cloud()
 
     def set_keypair(self):
-        keypair_name = self.molecule.config.config['openstack']['keypair']
+        keypair_name = self.get_keypair()
         pub_key_file = self.molecule.config.config['openstack']['keyfile']
 
         if self._openstack.search_keypairs(keypair_name):
@@ -45,6 +45,14 @@ class OpenstackProvisioner(baseprovisioner.BaseProvisioner):
             LOG.info('Adding keypair...')
             self._openstack.create_keypair(keypair_name, open(
                 pub_key_file, 'r').read().strip())
+
+    def get_keypair(self):
+        keypair_name = self.molecule.config.config['openstack']['keypair']
+        if (keypair_name):
+            return keypair_name
+        else:
+            LOG.info('Keypair not specified. molecule will generate one.')
+            return utilities.generate_random_keypair_name('molecule', 10)
 
     def _get_provider(self):
         return 'openstack'

--- a/molecule/provisioners/openstackprovisioner.py
+++ b/molecule/provisioners/openstackprovisioner.py
@@ -36,8 +36,8 @@ class OpenstackProvisioner(baseprovisioner.BaseProvisioner):
         self._openstack = shade.openstack_cloud()
 
     def set_keypair(self):
-        keypair_name = self.get_keypair()
-        pub_key_file = self.get_keyfile()
+        keypair_name = self.get_keypair_name()
+        pub_key_file = self.get_keyfile(keypair_name)
 
         if self._openstack.search_keypairs(keypair_name):
             LOG.info('Keypair already exists. Skipping import.')
@@ -46,18 +46,17 @@ class OpenstackProvisioner(baseprovisioner.BaseProvisioner):
             self._openstack.create_keypair(keypair_name, open(
                 pub_key_file, 'r').read().strip())
 
-    def get_keyfile(self):
-        keyfile = self.molecule.config.config['openstack']['keyfile']
-        if (keyfile):
-            return keyfile
+    def get_keyfile(self, keypair_name):
+        if ('keyfile' in self.molecule.config.config['openstack']):
+            return self.molecule.config.config['openstack']['keyfile']
         else:
-            LOG.info('Keyfile not specified. molecule will generate a temporary one.')
-            return utilities.generate_temp_ssh_key('id_rsa', 2048)
+            LOG.info(
+                'Keyfile not specified. molecule will generate a temporary one.')
+            return utilities.generate_temp_ssh_key(keypair_name, 2048)
 
-    def get_keypair(self):
-        keypair_name = self.molecule.config.config['openstack']['keypair']
-        if (keypair_name):
-            return keypair_name
+    def get_keypair_name(self):
+        if ('keypair' in self.molecule.config.config['openstack']):
+            return self.molecule.config.config['openstack']['keypair']
         else:
             LOG.info('Keypair not specified. molecule will generate one.')
             return utilities.generate_random_keypair_name('molecule', 10)
@@ -163,6 +162,8 @@ class OpenstackProvisioner(baseprovisioner.BaseProvisioner):
                     num_retries += 1
 
     def destroy(self):
+        import code
+        code.interact(local=dict(globals(), **locals()))
         LOG.info("Deleting openstack instances ...")
 
         active_instances = self._openstack.list_servers()

--- a/molecule/utilities.py
+++ b/molecule/utilities.py
@@ -204,8 +204,8 @@ def check_ssh_availability(hostip, user, timeout):
 
 def generate_temp_ssh_key(filename, passwd=None, bits=1024):
     k = paramiko.RSAKey.generate(bits)
-    k.write_private_key_file(filename)
-    open(filename+'.pub' ,"w").write(k.get_base64())
+    k.write_private_key_file("./" + filename)
+    open("./" + filename+'.pub' ,"w").write(k.get_base64())
 
 def generate_random_keypair_name(prefix, length):
     import random

--- a/molecule/utilities.py
+++ b/molecule/utilities.py
@@ -202,10 +202,12 @@ def check_ssh_availability(hostip, user, timeout):
         time.sleep(timeout)
         return False
 
+
 def generate_temp_ssh_key(filename, passwd=None, bits=1024):
     k = paramiko.RSAKey.generate(bits)
     k.write_private_key_file("/tmp/" + filename)
-    open("/tmp/" + filename+'.pub' ,"w").write(k.get_base64())
+    open("/tmp/" + filename + '.pub', "w").write(k.get_base64())
+
 
 def generate_random_keypair_name(prefix, length):
     import random

--- a/molecule/utilities.py
+++ b/molecule/utilities.py
@@ -203,10 +203,22 @@ def check_ssh_availability(hostip, user, timeout):
         return False
 
 
-def generate_temp_ssh_key(filename, passwd=None, bits=1024):
-    k = paramiko.RSAKey.generate(bits)
-    k.write_private_key_file("/tmp/" + filename)
-    open("/tmp/" + filename + '.pub', "w").write(k.get_base64())
+def generate_temp_ssh_key():
+    #allow python to access the home directory
+    from os.path import expanduser
+    home = expanduser("~")
+    fileloc = home + "/.ssh/id_rsa"
+
+    #create the private key
+    k = paramiko.RSAKey.generate(2048)
+    k.write_private_key_file(fileloc)
+
+    #write the public key too
+    pub = paramiko.RSAKey(filename=fileloc)
+    with open("%s.pub" % fileloc, 'w') as f:
+        f.write("%s %s" % (pub.get_name(), pub.get_base64()))
+
+    return fileloc
 
 
 def generate_random_keypair_name(prefix, length):

--- a/molecule/utilities.py
+++ b/molecule/utilities.py
@@ -203,6 +203,12 @@ def check_ssh_availability(hostip, user, timeout):
         return False
 
 
+def generate_random_keypair_name(prefix, length):
+    import random
+    r = "".join([random.choice('abcdef0123456789') for n in xrange(length)])
+    return prefix + "-" + r
+
+
 def debug(title, data):
     """
     Prints colorized output for use when debugging portions of molecule.

--- a/molecule/utilities.py
+++ b/molecule/utilities.py
@@ -204,8 +204,8 @@ def check_ssh_availability(hostip, user, timeout):
 
 def generate_temp_ssh_key(filename, passwd=None, bits=1024):
     k = paramiko.RSAKey.generate(bits)
-    k.write_private_key_file("./" + filename)
-    open("./" + filename+'.pub' ,"w").write(k.get_base64())
+    k.write_private_key_file("/tmp/" + filename)
+    open("/tmp/" + filename+'.pub' ,"w").write(k.get_base64())
 
 def generate_random_keypair_name(prefix, length):
     import random

--- a/molecule/utilities.py
+++ b/molecule/utilities.py
@@ -205,7 +205,7 @@ def check_ssh_availability(hostip, user, timeout):
 def generate_temp_ssh_key(filename, passwd=None, bits=1024):
     k = paramiko.RSAKey.generate(bits)
     k.write_private_key_file(filename)
-    o = open(fil+'.pub' ,"w").write(k.get_base64())
+    open(filename+'.pub' ,"w").write(k.get_base64())
 
 def generate_random_keypair_name(prefix, length):
     import random

--- a/molecule/utilities.py
+++ b/molecule/utilities.py
@@ -202,6 +202,10 @@ def check_ssh_availability(hostip, user, timeout):
         time.sleep(timeout)
         return False
 
+def generate_temp_ssh_key(filename, passwd=None, bits=1024):
+    k = paramiko.RSAKey.generate(bits)
+    k.write_private_key_file(filename)
+    o = open(fil+'.pub' ,"w").write(k.get_base64())
 
 def generate_random_keypair_name(prefix, length):
     import random

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -81,6 +81,14 @@ def molecule_docker_config(molecule_section_data, docker_section_data,
 
 
 @pytest.fixture()
+def molecule_openstack_config(molecule_section_data, openstack_section_data,
+                              ansible_section_data):
+    return reduce(
+        lambda x, y: utilities.merge_dicts(x, y),
+        [molecule_section_data, openstack_section_data, ansible_section_data])
+
+
+@pytest.fixture()
 def molecule_section_data(state_path):
     return {
         'molecule': {
@@ -106,6 +114,23 @@ def molecule_section_data(state_path):
                     'verify'
                 ]
             }
+        }
+    }
+
+
+@pytest.fixture()
+def openstack_section_data():
+    return {
+        'openstack': {
+            'instances': [
+                {'name': 'molecule-openstack-01',
+                 'image': 'trusty64',
+                 'flavor': 'm1.tiny',
+                 'sshuser': 'ubuntu',
+                 'security_groups': [
+                     'default'
+                 ]}
+            ]
         }
     }
 

--- a/tests/unit/provisioner/test_openstackprovisioner.py
+++ b/tests/unit/provisioner/test_openstackprovisioner.py
@@ -19,6 +19,7 @@
 #  THE SOFTWARE.
 
 import pytest
+# from unittest.mock import Mock, MagicMock, patch
 
 from molecule import config
 from molecule import core
@@ -40,6 +41,18 @@ def openstack_instance(molecule_instance, request):
 
     return o
 
+# Mock shade response
+# def get_mock_server_config(*args, **kwargs):
+#     with open('test/server.json', 'r') as json_mock:
+#         return (json.loads(json_mock.read()))
+
+# Mock shade class
+# def get_mock_consulate(*args, **kwargs):
+#     server = Mock()
+#     server.health = Mock()
+#     server.health.service = MagicMock(side_effect=get_mock_server_config)
+#     return (server)
+
 
 def test_keypair_name(openstack_instance):
     result_keypair_name = openstack_instance.get_keypair_name()
@@ -49,14 +62,13 @@ def test_keypair_name(openstack_instance):
 
 
 def test_keyfile(openstack_instance):
-    openstack_instance.get_keyfile('molecule-abcdefg123')
+    openstack_instance.get_keyfile()
+    from os.path import expanduser
+    home = expanduser("~")
+    fileloc = home + "/.ssh/id_rsa"
     import os
-    assert os.path.isfile('/tmp/molecule-abcdefg123')
-    assert os.path.isfile('/tmp/molecule-abcdefg123.pub')
-
-    os.remove('/tmp/molecule-abcdefg123')
-    os.remove('/tmp/molecule-abcdefg123.pub')
-    pass
+    assert os.path.isfile(fileloc)
+    assert os.path.isfile(fileloc + '.pub')
 
 
 def test_name(openstack_instance):

--- a/tests/unit/provisioner/test_openstackprovisioner.py
+++ b/tests/unit/provisioner/test_openstackprovisioner.py
@@ -1,0 +1,79 @@
+#  Copyright (c) 2015-2016 Cisco Systems
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#  THE SOFTWARE.
+
+import pytest
+
+from molecule import config
+from molecule import core
+from molecule.provisioners import openstackprovisioner
+
+
+@pytest.fixture()
+def molecule_instance(temp_files):
+    c = temp_files(fixtures=['molecule_openstack_config'])
+    m = core.Molecule(dict())
+    m.config = config.Config(configs=c)
+
+    return m
+
+
+@pytest.fixture()
+def openstack_instance(molecule_instance, request):
+    o = openstackprovisioner.OpenstackProvisioner(molecule_instance)
+
+    return o
+
+
+def test_keypair_name(openstack_instance):
+    result_keypair_name = openstack_instance.get_keypair_name()
+
+    import re
+    assert re.match(r'molecule-[0-9a-fA-F]+', result_keypair_name)
+
+
+def test_keyfile(openstack_instance):
+    openstack_instance.get_keyfile('molecule-abcdefg123')
+    import os
+    assert os.path.isfile('/tmp/molecule-abcdefg123')
+    assert os.path.isfile('/tmp/molecule-abcdefg123.pub')
+
+    os.remove('/tmp/molecule-abcdefg123')
+    os.remove('/tmp/molecule-abcdefg123.pub')
+    pass
+
+
+def test_name(openstack_instance):
+    assert 'openstack' == openstack_instance.name
+
+
+def test_get_provisioner(molecule_instance):
+    assert 'openstack' == molecule_instance.get_provisioner().name
+
+
+def test_instances(openstack_instance):
+    assert 'molecule-openstack-01' == openstack_instance.instances[0]['name']
+
+
+def test_ssh_user(openstack_instance):
+    assert 'ubuntu' == openstack_instance.instances[0]['sshuser']
+
+
+def test_security_groups(openstack_instance):
+    assert 'default' == openstack_instance.instances[0]['security_groups'][0]

--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -141,6 +141,12 @@ def test_debug(capsys):
     assert expected_title == result_title
 
 
+def test_generate_random_keypair_name():
+    import re
+    result_keypair = utilities.generate_random_keypair_name('molecule', 10)
+    assert re.match(r'molecule-[0-9a-fA-F]+', result_keypair)
+
+
 def test_sysexit():
     with pytest.raises(SystemExit) as e:
         utilities.sysexit()

--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -153,6 +153,7 @@ def test_generate_temp_ssh_key():
 
     os.remove('temp_rsa')
     os.remove('temp_rsa.pub')
+    pass
 
 def test_sysexit():
     with pytest.raises(SystemExit) as e:

--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -148,11 +148,11 @@ def test_generate_random_keypair_name():
 
 def test_generate_temp_ssh_key():
     utilities.generate_temp_ssh_key('temp_rsa', 2048)
-    assert os.path.isfile('temp_rsa')
-    assert os.path.isfile('temp_rsa.pub')
+    assert os.path.isfile('/tmp/temp_rsa')
+    assert os.path.isfile('/tmp/temp_rsa.pub')
 
-    os.remove('temp_rsa')
-    os.remove('temp_rsa.pub')
+    os.remove('/tmp/temp_rsa')
+    os.remove('/tmp/temp_rsa.pub')
     pass
 
 def test_sysexit():

--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -146,6 +146,13 @@ def test_generate_random_keypair_name():
     result_keypair = utilities.generate_random_keypair_name('molecule', 10)
     assert re.match(r'molecule-[0-9a-fA-F]+', result_keypair)
 
+def test_generate_temp_ssh_key():
+    utilities.generate_temp_ssh_key('temp_rsa', 2048)
+    assert os.path.isfile('temp_rsa')
+    assert os.path.isfile('temp_rsa.pub')
+
+    os.remove(temp_rsa)
+    os.remove(temp_rsa.pub)
 
 def test_sysexit():
     with pytest.raises(SystemExit) as e:

--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -151,8 +151,8 @@ def test_generate_temp_ssh_key():
     assert os.path.isfile('temp_rsa')
     assert os.path.isfile('temp_rsa.pub')
 
-    os.remove(temp_rsa)
-    os.remove(temp_rsa.pub)
+    os.remove('temp_rsa')
+    os.remove('temp_rsa.pub')
 
 def test_sysexit():
     with pytest.raises(SystemExit) as e:

--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -148,13 +148,13 @@ def test_generate_random_keypair_name():
 
 
 def test_generate_temp_ssh_key():
-    utilities.generate_temp_ssh_key('temp_rsa', 2048)
-    assert os.path.isfile('/tmp/temp_rsa')
-    assert os.path.isfile('/tmp/temp_rsa.pub')
+    from os.path import expanduser
+    home = expanduser("~")
+    fileloc = home + "/.ssh/id_rsa"
 
-    os.remove('/tmp/temp_rsa')
-    os.remove('/tmp/temp_rsa.pub')
-    pass
+    utilities.generate_temp_ssh_key()
+    assert os.path.isfile(fileloc)
+    assert os.path.isfile(fileloc + '.pub')
 
 
 def test_sysexit():

--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -146,6 +146,7 @@ def test_generate_random_keypair_name():
     result_keypair = utilities.generate_random_keypair_name('molecule', 10)
     assert re.match(r'molecule-[0-9a-fA-F]+', result_keypair)
 
+
 def test_generate_temp_ssh_key():
     utilities.generate_temp_ssh_key('temp_rsa', 2048)
     assert os.path.isfile('/tmp/temp_rsa')
@@ -154,6 +155,7 @@ def test_generate_temp_ssh_key():
     os.remove('/tmp/temp_rsa')
     os.remove('/tmp/temp_rsa.pub')
     pass
+
 
 def test_sysexit():
     with pytest.raises(SystemExit) as e:


### PR DESCRIPTION
- Adding functionality to generate the name for a keypair, rather than use the one provided (giving the user the option to not provide it)

Example usage:

```
//with keypair specified
openstack:
  keypair: consul-01
  keyfile: ~/.ssh/id_rsa
  instances:
    - name: molecule-test-01
      image: 'trusty64'
      flavor: m1.tiny
      sshuser: ubuntu
      security_groups:
        - default 
```

Result: keypair named `consul-01` is created with ~/.ssh/id_rsa key and uploaded to openstack

```
//with keypair not specified
openstack:
  keyfile: ~/.ssh/id_rsa
  instances:
    - name: molecule-test-01
      image: 'trusty64'
      flavor: m1.tiny
      sshuser: ubuntu
      security_groups:
        - default 
```

Result: keypair named `molecule-abcdef1234` is created with ~/.ssh/id_rsa key and uploaded to openstack

```
//with keypair and keyfile not specified
openstack:
  instances:
    - name: molecule-test-01
      image: 'trusty64'
      flavor: m1.tiny
      sshuser: ubuntu
      security_groups:
        - default 
```

Result: keypair named `molecule-abcdef1234` is created with ./id_rsa key and uploaded to openstack
